### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 	mavenLocal()
 	mavenCentral()
 	jcenter()
-	maven { url "http://spinnaker.bintray.com/gradle" }
+	maven { url "https://spinnaker.bintray.com/gradle" }
 }
 
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://spinnaker.bintray.com/gradle migrated to:  
  https://spinnaker.bintray.com/gradle ([https](https://spinnaker.bintray.com/gradle) result 301).